### PR TITLE
Revert "Added PIC compatability to the sdk"

### DIFF
--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -5,7 +5,7 @@ AS_FLAGS:=
 
 CC:=sh4aeb-elf-g++
 
-CC_FLAGS:=-fPIC -ffreestanding -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -m4a-nofpu -Wall -Wextra -Os -I include/
+CC_FLAGS:=-ffreestanding -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -m4a-nofpu -Wall -Wextra -Os -I include/
 
 AR:=sh4aeb-elf-ar
 AR_FLAGS:=src

--- a/sdk/os/functions/_util.inc
+++ b/sdk/os/functions/_util.inc
@@ -1,14 +1,4 @@
 .macro DEFINE_OS_FUNC name, addr
-    .text
-    .balign 4
-    .global _\name
-    .type _\name, @function
-_\name:
-    mov.l .addr_\name, r1
-    jmp @r1
-    nop
-    .balign 4
-.addr_\name:
-    .long \addr
-    .size _\name, .-_\name
+.globl _\name
+.set _\name, \addr
 .endm


### PR DESCRIPTION
Reverts QBos07/hollyhock-3#2

Forgot that gnu ld does not handle such cases in bare metal